### PR TITLE
add desimeter.log to avoid desiutil dependency

### DIFF
--- a/bin/desi_fvc_proc.py
+++ b/bin/desi_fvc_proc.py
@@ -10,7 +10,7 @@ import fitsio
 from pkg_resources import resource_filename
 
 from astropy.table import Table
-from desiutil.log import get_logger
+from desimeter.log import get_logger
 from desimeter.detectspots import detectspots
 from desimeter.findfiducials import findfiducials
 #from desimeter.transform.fvc2fp.poly2d import FVCFP_Polynomial

--- a/bin/write_focal_plane_metrology.py
+++ b/bin/write_focal_plane_metrology.py
@@ -5,7 +5,7 @@ import argparse
 import sys,os
 import numpy as np
 import yaml
-from desiutil.log import get_logger
+from desimeter.log import get_logger
 from pkg_resources import resource_filename
 from astropy.table import Table
 from desimeter.ptl2fp import apply_ptl2fp

--- a/py/desimeter/detectspots.py
+++ b/py/desimeter/detectspots.py
@@ -4,7 +4,7 @@ Utility functions to detect spots in fiber view camera image
 """
 import sys
 import numpy as np
-from desiutil.log import get_logger
+from desimeter.log import get_logger
 from astropy.table import Table
 from scipy.signal import fftconvolve
 from scipy.special import erf

--- a/py/desimeter/findfiducials.py
+++ b/py/desimeter/findfiducials.py
@@ -4,7 +4,7 @@ Utility functions to find fiducials in a list of spots given a know pattern of p
 
 import os,sys
 import numpy as np
-from desiutil.log import get_logger
+from desimeter.log import get_logger
 from astropy.table import Table,Column
 from pkg_resources import resource_filename
 from scipy.spatial import cKDTree as KDTree

--- a/py/desimeter/log.py
+++ b/py/desimeter/log.py
@@ -1,0 +1,45 @@
+import os
+import logging
+
+#- subset of desiutil.log.get_logger, to avoid desiutil dependency
+#- adapted from https://docs.python.org/3/howto/logging.html#configuring-logging
+
+_loggers = dict()
+def get_logger(level=None):
+
+    if level is None:
+        level = os.getenv('DESI_LOGLEVEL', 'INFO').upper()
+
+    if level == 'DEBUG':
+        loglevel = logging.DEBUG
+    elif level == 'INFO':
+        loglevel = logging.INFO
+    elif level == 'WARN' or level == 'WARNING':
+        loglevel = logging.WARNING
+    elif level == 'ERROR':
+        loglevel = logging.ERROR
+    elif level == 'FATAL' or level == 'CRITICAL':
+        loglevel = logging.CRITICAL
+    else:
+        raise ValueError('Unknown log level {}; should be DEBUG/INFO/WARNING/ERROR/CRITICAL'.format(level))
+
+    if level not in _loggers:
+        logger = logging.getLogger('desimeter.'+level)
+        logger.setLevel(loglevel)
+
+        # create console handler and set level to debug
+        ch = logging.StreamHandler()
+        ch.setLevel(loglevel)
+
+        # create formatter
+        formatter = logging.Formatter('%(levelname)s:%(filename)s:%(lineno)s:%(funcName)s:%(message)s')
+
+        # add formatter to ch
+        ch.setFormatter(formatter)
+
+        # add ch to logger
+        logger.addHandler(ch)
+        
+        _loggers[level] = logger
+
+    return _loggers[level]

--- a/py/desimeter/log.py
+++ b/py/desimeter/log.py
@@ -2,7 +2,6 @@ import os
 import logging
 
 #- subset of desiutil.log.get_logger, to avoid desiutil dependency
-#- adapted from https://docs.python.org/3/howto/logging.html#configuring-logging
 
 _loggers = dict()
 def get_logger(level=None):
@@ -26,6 +25,9 @@ def get_logger(level=None):
     if level not in _loggers:
         logger = logging.getLogger('desimeter.'+level)
         logger.setLevel(loglevel)
+
+        #- handler and formatter code adapted from
+        #- https://docs.python.org/3/howto/logging.html#configuring-logging
 
         # create console handler and set level to debug
         ch = logging.StreamHandler()

--- a/py/desimeter/ptl2fp.py
+++ b/py/desimeter/ptl2fp.py
@@ -3,7 +3,7 @@ Utility functions to fit and apply coordinates transformation from PTL (petal lo
 """
 
 import numpy as np
-from desiutil.log import get_logger
+from desimeter.log import get_logger
 from astropy.table import Table,Column
 from pkg_resources import resource_filename
 

--- a/py/desimeter/transform/fvc2fp/poly2d.py
+++ b/py/desimeter/transform/fvc2fp/poly2d.py
@@ -10,7 +10,7 @@ import numpy as np
 from astropy.table import Table,Column
 
 # from desimodel.focalplane.geometry import qs2xy,xy2qs
-from desiutil.log import get_logger
+from desimeter.log import get_logger
 
 from .base import FVC2FP_Base
 

--- a/py/desimeter/transform/fvc2fp/zb.py
+++ b/py/desimeter/transform/fvc2fp/zb.py
@@ -11,7 +11,7 @@ from astropy.table import Table,Column
 from scipy.optimize import minimize
 
 # from desimodel.focalplane.geometry import qs2xy,xy2qs
-from desiutil.log import get_logger
+from desimeter.log import get_logger
 
 from .base import FVC2FP_Base
 from desimeter.transform.zhaoburge import getZhaoBurgeXY, getZhaoBurgeTerm


### PR DESCRIPTION
Adds `desimeter.log.get_logger()` to remove the desiutil dependency.

Depending upon how desimeter evolves, we may want to switch back to using `desiutil.log.get_logger()` and bring in other desiutil and desimodel dependencies, but for now this simplifies use by others outside of the desidata environment.
